### PR TITLE
Update btagging R22 (#1532)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,13 +43,13 @@ atlas_add_library( xAODAnaHelpersLib xAODAnaHelpers/*.h Root/*.h Root/*.cxx ${xA
                    ElectronPhotonShowerShapeFudgeToolLib
                    FTagAnalysisInterfacesLib JetAnalysisInterfacesLib MuonAnalysisInterfacesLib
                    PhotonEfficiencyCorrectionLib METUtilitiesLib METInterface
-                   TauAnalysisToolsLib AsgTools xAODMissingET 
+                   TauAnalysisToolsLib AsgTools xAODMissingET
                    AssociationUtilsLib JetEDM JetUncertaintiesLib
-                   JetCPInterfaces xAODBTaggingEfficiencyLib TrigConfxAODLib
+                   JetCPInterfaces xAODBTagging xAODBTaggingEfficiencyLib TrigConfxAODLib
                    TrigDecisionToolLib xAODCutFlow JetMomentToolsLib
                    TriggerMatchingToolLib xAODMetaDataCnv xAODMetaData
-                   JetJvtEfficiencyLib
-                   #PMGToolsLib JetSubStructureUtils JetTileCorrectionLib BoostedJetTaggersLib JetResolutionLib
+                   JetJvtEfficiencyLib PMGToolsLib SystematicsHandlesLib
+                   JetSubStructureUtils JetTileCorrectionLib BoostedJetTaggersLib
                    ${release_libs}
 )
 

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -2980,45 +2980,45 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     }
 
     // MV2c taggers
-    double val;
+    float val;
 
     val=-999;
-    myBTag->variable<double>("MV2c00"   , "discriminant", val);
+    myBTag->variable<float>("MV2c00"   , "discriminant", val);
     m_MV2c00   ->push_back( val );
 
     val=-999;
-    myBTag->variable<double>("MV2c10"   , "discriminant", val);
+    myBTag->variable<float>("MV2c10"   , "discriminant", val);
     m_MV2c10   ->push_back( val );
     val=-999;
-    myBTag->variable<double>("MV2c10mu" , "discriminant", val);
+    myBTag->variable<float>("MV2c10mu" , "discriminant", val);
     m_MV2c10mu ->push_back( val );
 
     val=-999;
-    myBTag->variable<double>("MV2c10rnn", "discriminant", val);
+    myBTag->variable<float>("MV2c10rnn", "discriminant", val);
     m_MV2c10rnn->push_back( val );
     val=-999;
-    myBTag->variable<double>("MV2c20"   , "discriminant", val);
+    myBTag->variable<float>("MV2c20"   , "discriminant", val);
     m_MV2c20   ->push_back( val );
 
     val=-999;
-    myBTag->variable<double>("MV2rmu" , "discriminant", val);
+    myBTag->variable<float>("MV2rmu" , "discriminant", val);
     m_MV2rmu ->push_back( val );
 
     val=-999;
-    myBTag->variable<double>("MV2r", "discriminant", val);
+    myBTag->variable<float>("MV2r", "discriminant", val);
     m_MV2r->push_back( val );
 
     val=-999;
-    myBTag->variable<double>("MV2c100"  , "discriminant", val);
+    myBTag->variable<float>("MV2c100"  , "discriminant", val);
     m_MV2c100  ->push_back( val );
 
     // DL1 taggers
-    double pu, pb, pc, score;
+    float pu, pb, pc, score;
 
     pu=0; pb=0; pc=0;
-    myBTag->variable<double>("DL1" , "pu", pu);
-    myBTag->variable<double>("DL1" , "pc", pc);
-    myBTag->variable<double>("DL1" , "pb", pb);
+    myBTag->variable<float>("DL1" , "pu", pu);
+    myBTag->variable<float>("DL1" , "pc", pc);
+    myBTag->variable<float>("DL1" , "pb", pb);
     score=log( pb / (0.08*pc+0.92*pu) );
     m_DL1_pu->push_back(pu);
     m_DL1_pc->push_back(pc);
@@ -3026,9 +3026,9 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     m_DL1->push_back( score );
 
     pu=0; pb=0; pc=0;
-    myBTag->variable<double>("DL1mu" , "pu", pu);
-    myBTag->variable<double>("DL1mu" , "pc", pc);
-    myBTag->variable<double>("DL1mu" , "pb", pb);
+    myBTag->variable<float>("DL1mu" , "pu", pu);
+    myBTag->variable<float>("DL1mu" , "pc", pc);
+    myBTag->variable<float>("DL1mu" , "pb", pb);
     score=log( pb / (0.08*pc+0.92*pu) );
     m_DL1mu_pu->push_back(pu);
     m_DL1mu_pc->push_back(pc);
@@ -3036,9 +3036,9 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     m_DL1mu->push_back( score );
 
     pu=0; pb=0; pc=0;
-    myBTag->variable<double>("DL1rnn" , "pu", pu);
-    myBTag->variable<double>("DL1rnn" , "pc", pc);
-    myBTag->variable<double>("DL1rnn" , "pb", pb);
+    myBTag->variable<float>("DL1rnn" , "pu", pu);
+    myBTag->variable<float>("DL1rnn" , "pc", pc);
+    myBTag->variable<float>("DL1rnn" , "pb", pb);
     score=log( pb / (0.03*pc+0.97*pu) );
     m_DL1rnn_pu->push_back(pu);
     m_DL1rnn_pc->push_back(pc);
@@ -3046,9 +3046,9 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     m_DL1rnn->push_back( score );
 
     pu=0; pb=0; pc=0;
-    myBTag->variable<double>("DL1rmu" , "pu", pu);
-    myBTag->variable<double>("DL1rmu" , "pc", pc);
-    myBTag->variable<double>("DL1rmu" , "pb", pb);
+    myBTag->variable<float>("DL1rmu" , "pu", pu);
+    myBTag->variable<float>("DL1rmu" , "pc", pc);
+    myBTag->variable<float>("DL1rmu" , "pb", pb);
     score=log( pb / (0.08*pc+0.92*pu) );
     m_DL1rmu_pu->push_back(pu);
     m_DL1rmu_pc->push_back(pc);
@@ -3056,9 +3056,9 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     m_DL1rmu->push_back( score );
 
     pu=0; pb=0; pc=0;
-    myBTag->variable<double>("DL1r" , "pu", pu);
-    myBTag->variable<double>("DL1r" , "pc", pc);
-    myBTag->variable<double>("DL1r" , "pb", pb);
+    myBTag->variable<float>("DL1r" , "pu", pu);
+    myBTag->variable<float>("DL1r" , "pc", pc);
+    myBTag->variable<float>("DL1r" , "pb", pb);
     score=log( pb / (0.03*pc+0.97*pu) );
     m_DL1r_pu->push_back(pu);
     m_DL1r_pc->push_back(pc);


### PR DESCRIPTION
* Update btagging types and package dependencies

* Fix PF-based MET in R22 (#1489)

* Enable setting of map index in BJetEfficiencyCorrector (#1478)

* Fix listTrigChains lepton branch

* Missing fix in MuonContainer for listTrigChains

* Allow to turn ON ApplyRelPt in OverlapRemover

* Enable global trigger SFs

Take into account combinatorics when requested

* Fix typo

* Attemp to fix BTag SFs

* Simplify

* Remove unnecessary changes

* Fix spacing

* Improve getMCIndex()

* Do not get jet flavour if not needed!

* just rerunning CI tests

* just rerunning CI tests

* Simplify and bugfix

Co-authored-by: Jonathan Bossio <jonathan.bossio@cern.ch>

* Fix listTrigChains lepton branch and allow to turn ON ApplyRelPt in OveralRemover (#1467)

* Fix listTrigChains lepton branch

* Missing fix in MuonContainer for listTrigChains

* Allow to turn ON ApplyRelPt in OverlapRemover

Co-authored-by: Jonathan Bossio <jonathan.bossio@cern.ch>

* Enable event-level lepton trigger SFs (#1471)

* Fix listTrigChains lepton branch

* Missing fix in MuonContainer for listTrigChains

* Allow to turn ON ApplyRelPt in OverlapRemover

* Enable global trigger SFs

Take into account combinatorics when requested

* Fix typo

Co-authored-by: Jonathan Bossio <jonathan.bossio@cern.ch>

* Bring back MET reconstruction into R22

* Move to 22.2.16

* Set correct ConfigPrefix for PF-based MET

* Allow 2 enable DoMuonPFlowBugfix in METConstructor (#1488)

Co-authored-by: Jonathan Bossio <jonathan.bossio@cern.ch>

* Allow 2 enable DoMuonPFlowBugfix in METConstructor (#1488)

Co-authored-by: Jonathan Bossio <jonathan.bossio@cern.ch>

Co-authored-by: Jonathan Bossio <jonathan.bossio@cern.ch>

* Fix JVFcorr moment name and use JVT w/o truth jets (#1492)

Co-authored-by: Jonathan Bossio <jonathan.bossio@cern.ch>

* Fix JVT SF ERROR (#1493)

* Fix JVFcorr moment name and use JVT w/o truth jets

* Fix JVT ERROR

Co-authored-by: Jonathan Bossio <jonathan.bossio@cern.ch>

* Adding an additional Jet information string to add to the tree the PFO-related information for PFlow jets - SumPtChargedPFOPt500PV and fCharged (#1495)

* Fix missing headers for messaging macro (#1497)


* Allow 2 enable DoMuonPFlowBugfix in METConstructor (#1488)

Co-authored-by: Jonathan Bossio <jonathan.bossio@cern.ch>

* Fix remaining "AsgTools/MessageCheck.h"

Co-authored-by: Jonathan Bossio <jonathan.bossio@cern.ch>

* Adding protection for filling of fCharged when jet pT at constituent scale is 0 (#1498)

* Adding protection for cases where jetconstitP4.Pt() is zero

* Allow to save beamSpotWeight to TTrees if requested (#1501)

Co-authored-by: Jonathan Bossio <jonathan.bossio@cern.ch>

* Fix JVT SF protection (should be done only on MC) (#1516)

Co-authored-by: Jonathan Bossio <jonathan.bossio@cern.ch>

* Correct setBranch for significance branches, /F is incorrect should be F (#1518)

* Added LooseBadLLP jet cleaning WP (#1520)

* update isPHYS to work for PHYSLLP

* added LooseBadLLP to jet cleaning

* removed whitespaces

* test out of removal of whitespace

* included LooseBadLLP cut in jet-cleaning

* removed extra whitespaces

* removed extra whitespaces

* adjusted WP LooseBadLLP into an infoswitch

* included jet clean infoswitch in OR and fixed or->|| in Algorithm.cxx

Co-authored-by: Jackson Burzynski <jackson.carl.burzynski@cern.ch>

* Make Taus work in R22 (#1522)

* Removed working points that are no longer avaiable

* removed obsolete EfficiencyCorrectionType (SFxxxxx) parameters. Note, two new ones that appear, SFEleIDElectron and SFDecayModeHadTau, may need to be added

* Renamed IDLevel->JetIDLevel and OLRLevel->EleIDLevel, and changed their options to those avaiable after the update

* an assortmant of updates, and trying to make names consistant with updates

* updateing release

* updateing release

* Added library for isSuccess|

Co-authored-by: Henry Day-Hall <Henry.Day-Hall@cern.ch>

* Support CP algorithms in xAH_config.algorithm() (through AnaAlgSequence) (#1530)

* Support CP algs through cp_sequence xAH_run method

* Add CP algorithms through algorithm() instead of

cp_sequence()

* Fix comment

* Simplify and add warning

* Fix name of library

Co-authored-by: Bill Balunas <bill.balunas@cern.ch>
Co-authored-by: Jonathan Bossio <jonathan.bossio@cern.ch>
Co-authored-by: Ricardo Barrué <61161376+rbarrue@users.noreply.github.com>
Co-authored-by: flumeware <flumeware@users.noreply.github.com>
Co-authored-by: Darij-Starko <darij.markian.starko@cern.ch>
Co-authored-by: Jackson Burzynski <jackson.carl.burzynski@cern.ch>
Co-authored-by: HenryDayHall <henrydayhall@protonmail.com>
Co-authored-by: Henry Day-Hall <Henry.Day-Hall@cern.ch>